### PR TITLE
fix: adjust when rule has general and more than one specific path

### DIFF
--- a/src/grouped-imports.ts
+++ b/src/grouped-imports.ts
@@ -290,7 +290,7 @@ const getImportsByGroup = (
           (/\.\w/gi.test(importValue) && !/\.\w/gi.test(groupPath));
 
         return regularImport && !similarImport;
-      });
+      }) && !(allOptionsPaths.includes(node.source.value as string) && !groupPaths.includes(node.source.value as string));
     });
 
     return {

--- a/src/grouped-imports.ts
+++ b/src/grouped-imports.ts
@@ -279,7 +279,9 @@ const getImportsByGroup = (
   return _.reduce(options, (acc, option, key) => {
     const groupPaths = _.map(option, o => o.path);
     const filteredImports = _.filter(importNodes, (node) => {
-      return _.some(groupPaths, (groupPath) => {
+      const isCurrentNodeInGroupAndPath = (_.includes(allOptionsPaths, node.source.value) && !_.includes(groupPaths, node.source.value));
+
+      return !isCurrentNodeInGroupAndPath && _.some(groupPaths, (groupPath) => {
 
         // check if there's a more specific path in option values
         const similarOptionValue =
@@ -290,7 +292,7 @@ const getImportsByGroup = (
           (/\.\w/gi.test(importValue) && !/\.\w/gi.test(groupPath));
 
         return regularImport && !similarImport;
-      }) && !(allOptionsPaths.includes(node.source.value as string) && !groupPaths.includes(node.source.value as string));
+      });
     });
 
     return {

--- a/tests/grouped-imports.test.ts
+++ b/tests/grouped-imports.test.ts
@@ -41,6 +41,23 @@ import u from 'utils/functions';
       },
       {
         code: `
+import { parseDate } from 'utils/parser';
+import u from 'utils/functions';
+import { validateDate } from 'utils/validations';
+      `,
+        errors: [{ message: messages.noComments }],
+        options: ruleOptions,
+        output: `
+// parser
+import { parseDate } from 'utils/parser';
+// utils
+import u from 'utils/functions';
+// validations
+import { validateDate } from 'utils/validations';
+      `,
+      },
+      {
+        code: `
 import api from 'api/request';
 import select from 'selectors/main';
       `,
@@ -224,6 +241,8 @@ import select from 'selectors/main';
 // validations
 import { validateDate } from 'utils/validations';
 
+import { parseDate } from 'utils/parser';
+
 // utils
 import u from 'utils';
 
@@ -237,6 +256,8 @@ import { validateEmpty } from 'utils/validations';
 // validations
 import { validateDate } from 'utils/validations';
 import { validateEmpty } from 'utils/validations';
+
+import { parseDate } from 'utils/parser';
 
 // utils
 import u from 'utils';

--- a/tests/grouped-imports.test.ts
+++ b/tests/grouped-imports.test.ts
@@ -224,9 +224,6 @@ import select from 'selectors/main';
 // validations
 import { validateDate } from 'utils/validations';
 
-// dates
-import { parseDate } from 'utils/parser';
-
 // utils
 import u from 'utils';
 
@@ -240,9 +237,6 @@ import { validateEmpty } from 'utils/validations';
 // validations
 import { validateDate } from 'utils/validations';
 import { validateEmpty } from 'utils/validations';
-
-// dates
-import { parseDate } from 'utils/parser';
 
 // utils
 import u from 'utils';
@@ -758,6 +752,20 @@ import s from 'components/Comp.css';
 import 'some.css';
 // eslint-disable some-rule
 import s from './Dashboard.css';
+      `,
+        options: ruleOptions,
+      },
+      {
+        code:
+`
+// utils
+import u from 'utils/functions';
+
+// validations
+import { validateEmpty } from 'utils/validations';
+
+// parser
+import { parseDate } from 'utils/parser';
       `,
         options: ruleOptions,
       },

--- a/tests/grouped-imports.test.ts
+++ b/tests/grouped-imports.test.ts
@@ -8,6 +8,7 @@ const ruleOptions = [
   {
     'utils': [{ path: 'utils' }],
     'validations': [{ path: 'utils/validations' }],
+    'parser': [{ path: 'utils/parser' }],
     'api, selectors': [{ path: 'api/' }, { path: 'selectors/' }],
     'css': [{ path: '.css' }],
     'images': [{ path: '.png' }, { path: '.jpeg' }],
@@ -223,6 +224,9 @@ import select from 'selectors/main';
 // validations
 import { validateDate } from 'utils/validations';
 
+// dates
+import { parseDate } from 'utils/parser';
+
 // utils
 import u from 'utils';
 
@@ -236,6 +240,9 @@ import { validateEmpty } from 'utils/validations';
 // validations
 import { validateDate } from 'utils/validations';
 import { validateEmpty } from 'utils/validations';
+
+// dates
+import { parseDate } from 'utils/parser';
 
 // utils
 import u from 'utils';


### PR DESCRIPTION
**Problem**
When our rule has one **general** path and more than one **more specific** path, it fails in assigning properly the final result and it triggers an error.

Example:
```
{
    'utils': [{ path: 'utils' }],
    'validations': [{ path: 'utils/validations' }],
    'parser': [{ path: 'utils/parser' }],
}
```
Final result:
![Screenshot from 2023-10-19 12-24-11](https://github.com/kairome/eslint-plugin-grouped-import/assets/17968732/6edf146a-ed64-4c0c-9daa-e0aa2bb4f1e2)

**Solution**
If a more specific path is found, it checks if the general path already has its own path declared. If yes, then it won't try to assign the more specific path.